### PR TITLE
Turn on c++17 and get rid of boost::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2)
 
 project(omim C CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 get_filename_component(OMIM_ROOT . ABSOLUTE)
 
@@ -90,7 +90,7 @@ find_package(Threads)
 #init_boost()
 #install_boost_headers()
 
-find_package(Boost ${BOOST_VERSION} EXACT COMPONENTS system filesystem serialization iostreams REQUIRED)
+find_package(Boost ${BOOST_VERSION} EXACT COMPONENTS serialization iostreams REQUIRED)
 set(Boost_USE_MULTITHREADED ON)
 if (PLATFORM_MAC)
     set(Boost_USE_STATIC_LIBS ON)

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 omim_add_test_subdirectory(platform_tests_support)
 
 omim_add_library(${PROJECT_NAME} ${SRC})
-omim_link_libraries(${PROJECT_NAME} base coding jansson ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
+omim_link_libraries(${PROJECT_NAME} base coding jansson stdc++fs)
 
 
 if (APPLE)

--- a/platform/platform_std.cpp
+++ b/platform/platform_std.cpp
@@ -15,10 +15,12 @@
 #include <regex>
 #include <string>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
+#include <system_error>
+
 #include <boost/range/iterator_range.hpp>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 using namespace std;
 
@@ -43,7 +45,7 @@ bool Platform::GetFileSizeByName(string const & fileName, uint64_t & size) const
 void Platform::GetFilesByRegExp(string const & directory, string const & regexp,
                                 FilesList & outFiles)
 {
-  boost::system::error_code ec{};
+  std::error_code ec{};
   regex exp(regexp);
 
   for (auto const & entry : boost::make_iterator_range(fs::directory_iterator(directory, ec), {}))
@@ -57,7 +59,7 @@ void Platform::GetFilesByRegExp(string const & directory, string const & regexp,
 // static
 Platform::EError Platform::MkDir(string const & dirName)
 {
-  boost::system::error_code ec{};
+  std::error_code ec{};
 
   fs::path dirPath{dirName};
   if (fs::exists(dirPath, ec))


### PR DESCRIPTION
Предлагаю на посмотреть, но не мержить, пока мы не сможем перейти на gcc8 как на разработческих тачках, так и на github actions (автоматические unit test важнее)