### PR TITLE
Clang workflow

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,7 +2,8 @@ name: C/C++ CI
 
 on: [push]
 jobs:
-  build:
+  build_gcc:
+    name: GCC build and unit tests
     runs-on: ubuntu-18.04
     steps:
     - name: Install all boost
@@ -16,3 +17,17 @@ jobs:
     - name: make test
       run: env CTEST_OUTPUT_ON_FAILURE=1 make test
 
+  build_clang:
+    name: Clang build and unit tests
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Install all boost
+      run:  sudo apt install libboost-all-dev
+    - uses: actions/checkout@v1
+    - uses: textbook/git-checkout-submodule-action@2.0.0
+    - name: cmake
+      run: CC=`which clang` CXX=`which clang++` cmake .
+    - name: make
+      run: make -j 8
+    - name: make test
+      run: env CTEST_OUTPUT_ON_FAILURE=1 make test


### PR DESCRIPTION
Реквест отведен от ветки, где правится сборка clang с Werror, соответственно смотреть надо только последний коммит и сами проверки покликать
Проверки выполняются параллельно, и время отработки не страдает
